### PR TITLE
Update Hex Operators to distinguish nibble shift from traditional bit shift

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,20 +202,25 @@ h1 != UInt8(20)        // true   (comparing Hex<Int> with UInt8)
 
 Additional operators similarly supported, allowing mixing of types as with equatability:
 
-- `+=, -=, *=, /=, &`
+- `+=, -=, *=, /=, <<, >>, &`
 
 
 
 ## Bitwise Shifting
 
 ```swift
-var h = 0x1F.hex
+// traditional bit shift left/right still work as usual
 
-0x2F.hex << 1          // 0x2F0    (bitwise nibble shift left)
-0x2F.hex >> 1          // 0x2      (bitwise nibble shift right)
+0b0100.hex << 1        // 0b1000
+0b0100.hex >> 1        // 0b0010
 
-0x10.hex >> 1          // 0x1      (bitwise nibble shift right)
-0x10.hex << 4          // 0x100000 (bitwise nibble shift left)
+// nibble shift (multiples of 4 bits)
+
+0x2F.hex <<<< 1        // 0x2F0    (bitwise nibble shift left)
+0x2F.hex >>>> 1        // 0x2      (bitwise nibble shift right)
+
+0xF0.hex >>>> 1        // 0xF      (bitwise nibble shift right)
+0xF0.hex <<<< 4        // 0xF00000 (bitwise nibble shift left)
 ```
 
 

--- a/SwiftHex/Hex Operators.swift
+++ b/SwiftHex/Hex Operators.swift
@@ -158,26 +158,56 @@ public func /=<T>(lhs: inout T, rhs: Hex<T>) {
 
 // MARK: Bitwise operators
 
+infix operator >>>>: BitwiseShiftPrecedence
+infix operator <<<<: BitwiseShiftPrecedence
+
 extension Hex {
+
+	// nibble bit shift (4 binary places)
+	
+	static public func >>>>(lhs: Hex, rhs: Hex) -> Hex {
+		return Hex(lhs.value >> (rhs.value * 4))							// nibble shift - multiples of 4 bits
+	}
+	static public func >>>><U: BinaryInteger>(lhs: Hex, rhs: U) -> Hex {
+		return Hex(lhs.value >> (rhs * 4))									// nibble shift - multiples of 4 bits
+	}
+	static public func >>>><U: BinaryInteger>(lhs: U, rhs: Hex) -> Hex<U> {
+		return Hex<U>(lhs >> (rhs.value * 4))								// nibble shift - multiples of 4 bits
+	}
+	
+	static public func <<<<(lhs: Hex, rhs: Hex) -> Hex {
+		return Hex(lhs.value << (rhs.value * 4))							// nibble shift - multiples of 4 bits
+	}
+	static public func <<<<<U: BinaryInteger>(lhs: Hex, rhs: U) -> Hex {
+		return Hex(lhs.value << (rhs * 4))									// nibble shift - multiples of 4 bits
+	}
+	static public func <<<<<U: BinaryInteger>(lhs: U, rhs: Hex) -> Hex<U> {
+		return Hex<U>(lhs << (rhs.value * 4))								// nibble shift - multiples of 4 bits
+	}
+	
+	// bitshift left / right
+	
 	static public func >>(lhs: Hex, rhs: Hex) -> Hex {
-		return Hex(lhs.value >> (rhs.value * 4))							// shift base-16 places
+		return Hex(lhs.value >> rhs.value)									// traditional bit shift
 	}
 	static public func >><U: BinaryInteger>(lhs: Hex, rhs: U) -> Hex {
-		return Hex(lhs.value >> (rhs * 4))									// shift base-16 places
+		return Hex(lhs.value >> rhs)										// traditional bit shift
 	}
 	static public func >><U: BinaryInteger>(lhs: U, rhs: Hex) -> U {
-		return lhs >> rhs.value												// shift default bitwise
+		return lhs >> rhs.value												// traditional bit shift
 	}
 	
 	static public func <<(lhs: Hex, rhs: Hex) -> Hex {
-		return Hex(lhs.value << (rhs.value * 4))							// shift base-16 places
+		return Hex(lhs.value << rhs.value)									// traditional bit shift
 	}
 	static public func <<<U: BinaryInteger>(lhs: Hex, rhs: U) -> Hex {
-		return Hex(lhs.value << (rhs * 4))									// shift base-16 places
+		return Hex(lhs.value << rhs)										// traditional bit shift
 	}
 	static public func <<<U: BinaryInteger>(lhs: U, rhs: Hex) -> U {
-		return lhs << rhs.value												// shift default bitwise
+		return lhs << rhs.value												// traditional bit shift
 	}
+	
+	// bitshift &
 	
 	static public func &(lhs: Hex, rhs: Hex) -> Hex {
 		return Hex(lhs.value & rhs.value)									// filter mask: 0x0F, 0xF0, 0xFF, etc.


### PR DESCRIPTION
Making bit shift operators less ambiguous. << and >> now operate as expected, and two new operators <<<< and >>>> have been added to allow nibble shift (shift left or right in multiples of 4 bits).